### PR TITLE
Fix link to ast package

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![godoc.org][godoc-badge]][godoc]
 
-`comment` provides utilities for [ast.CommentMap](https://golang.org/go/ast/#CommentMap).
+`comment` provides utilities for [ast.CommentMap](https://golang.org/pkg/go/ast/#CommentMap).
 
 <!-- links -->
 [godoc]: https://godoc.org/github.com/gostaticanalysis/comment


### PR DESCRIPTION
## what
I relink ast.CommentMap document.

## why
link to document is broken.
<img width="420" alt="スクリーンショット 2019-10-07 15 10 48" src="https://user-images.githubusercontent.com/29445112/66288619-d4c7ea80-e914-11e9-83d2-3e2a54bb9f9f.png">
