### PR TITLE
comment: fix parse `//lint:ignore` comment on IgnoreLine

### DIFF
--- a/comment.go
+++ b/comment.go
@@ -92,8 +92,11 @@ func (maps Maps) CommentsByLine(fset *token.FileSet, line int) []*ast.CommentGro
 //   //lint:ignore Check1[,Check2,...,CheckN] reason
 func (maps Maps) IgnoreLine(fset *token.FileSet, line int, check string) bool {
 	for _, cg := range maps.CommentsByLine(fset, line) {
-		if hasIgnoreCheck(cg.Text(), check) {
-			return true
+		for _, c := range cg.List {
+			text := strings.TrimPrefix(strings.TrimSpace(c.Text), "//")
+			if hasIgnoreCheck(text, check) {
+				return true
+			}
 		}
 	}
 	return false


### PR DESCRIPTION
Fix parse `//lint:ignore` comment on `IgnoreLine`.

The `ast.CommentGroup.Text()` doesn't include a pragma style comment a such as `//lint:ignore`. 
Includes only have space after `//` IIRC.

Fixed also wrong parse `//lint:ignore, wrapper zagane's bug` pragma comment on zagane side.

---

Note that the `comment` package hasn't testdata, so I didn't write a testcase.