### PR TITLE
Fix logic error in hasIgnoreCheck

### DIFF
--- a/comment.go
+++ b/comment.go
@@ -123,7 +123,7 @@ func (maps Maps) IgnoreLine(fset *token.FileSet, line int, check string) bool {
 
 func hasIgnoreCheck(s, check string) bool {
 	txt := strings.Split(s, " ")
-	if len(txt) < 3 && txt[0] != "lint:ignore" {
+	if len(txt) < 3 || txt[0] != "lint:ignore" {
 		return false
 	}
 


### PR DESCRIPTION
Ensure that the "lint:ignore" directive is actually required to
ignore a check.

Fixes #10