### PR TITLE
Fix comment directive parsing in Go 1.15+

### DIFF
--- a/comment.go
+++ b/comment.go
@@ -55,7 +55,7 @@ func (maps Maps) Annotated(n ast.Node, annotation string) bool {
 //   //lint:ignore Check1[,Check2,...,CheckN] reason
 func (maps Maps) Ignore(n ast.Node, check string) bool {
 	for _, cg := range maps.Comments(n) {
-		if hasIgnoreCheck(cg.Text(), check) {
+		if hasIgnoreCheck(cg, check) {
 			return true
 		}
 	}
@@ -67,7 +67,7 @@ func (maps Maps) Ignore(n ast.Node, check string) bool {
 //   //lint:ignore Check1[,Check2,...,CheckN] reason
 func (maps Maps) IgnorePos(pos token.Pos, check string) bool {
 	for _, cg := range maps.CommentsByPos(pos) {
-		if hasIgnoreCheck(cg.Text(), check) {
+		if hasIgnoreCheck(cg, check) {
 			return true
 		}
 	}
@@ -76,7 +76,7 @@ func (maps Maps) IgnorePos(pos token.Pos, check string) bool {
 
 // Deprecated: This function does not work with multiple files.
 // CommentsByPosLine can be used instead of CommentsByLine.
-// 
+//
 // CommentsByLine returns correspond a CommentGroup slice to specified line.
 func (maps Maps) CommentsByLine(fset *token.FileSet, line int) []*ast.CommentGroup {
 	for i := range maps {
@@ -114,16 +114,26 @@ func (maps Maps) CommentsByPosLine(fset *token.FileSet, pos token.Pos) []*ast.Co
 //   //lint:ignore Check1[,Check2,...,CheckN] reason
 func (maps Maps) IgnoreLine(fset *token.FileSet, line int, check string) bool {
 	for _, cg := range maps.CommentsByLine(fset, line) {
-		if hasIgnoreCheck(cg.Text(), check) {
+		if hasIgnoreCheck(cg, check) {
 			return true
 		}
 	}
 	return false
 }
 
-func hasIgnoreCheck(s, check string) bool {
+// hasIgnoreCheck returns true if the provided CommentGroup starts with a comment
+// of the form "//lint:ignore Check1[,Check2,...,CheckN] reason" and one of the
+// checks matches the provided check. The *ast.CommentGroup is checked directly
+// rather than using "cg.Text()" because, starting in Go 1.15, the "cg.Text()" call
+// no longer returns directive-style comments (see https://github.com/golang/go/issues/37974).
+func hasIgnoreCheck(cg *ast.CommentGroup, check string) bool {
+	if !strings.HasPrefix(cg.List[0].Text, "//") {
+		return false
+	}
+
+	s := strings.TrimSpace(cg.List[0].Text[2:])
 	txt := strings.Split(s, " ")
-	if len(txt) < 3 && txt[0] != "lint:ignore" {
+	if len(txt) < 3 || txt[0] != "lint:ignore" {
 		return false
 	}
 

--- a/comment_test.go
+++ b/comment_test.go
@@ -16,7 +16,7 @@ func TestMaps_CommentsByPosLine(t *testing.T) {
 		want []string
 	}{
 		"single": {"testdata/Maps_CommentsByPosLine/single.go", []string{"a"}},
-		"multi": {"testdata/Maps_CommentsByPosLine/multi.go", []string{"b"}},
+		"multi":  {"testdata/Maps_CommentsByPosLine/multi.go", []string{"b"}},
 	}
 
 	for n, tt := range cases {
@@ -34,6 +34,34 @@ func TestMaps_CommentsByPosLine(t *testing.T) {
 
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf(diff)
+			}
+		})
+	}
+}
+
+func TestMaps_IgnoreLine(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		path  string
+		check string
+		line  int
+		want  bool
+	}{
+		"has_directive": {"testdata/Maps_IgnorePos/has_directive.go", "test-check", 4, true},
+		"no_directive":  {"testdata/Maps_IgnorePos/no_directive.go", "test-check", 4, false},
+	}
+
+	for n, tt := range cases {
+		tt := tt
+		t.Run(n, func(t *testing.T) {
+			t.Parallel()
+			fset := token.NewFileSet()
+			ms := maps(t, fset, tt.path)
+
+			got := ms.IgnoreLine(fset, tt.line, tt.check)
+			if tt.want != got {
+				t.Errorf("want %v, got %v", tt.want, got)
 			}
 		})
 	}

--- a/testdata/Maps_IgnorePos/has_directive.go
+++ b/testdata/Maps_IgnorePos/has_directive.go
@@ -1,0 +1,5 @@
+-- a.go --
+package a
+
+//lint:ignore test-check reason
+func A_() {}

--- a/testdata/Maps_IgnorePos/no_directive.go
+++ b/testdata/Maps_IgnorePos/no_directive.go
@@ -1,0 +1,5 @@
+-- a.go --
+package a
+
+// test-check reason
+func A_() {}


### PR DESCRIPTION
Go 1.15 changed the behavior of *ast.CommentGroup.Text() in a way
that breaks the functionality of this package. Updates the implementation
to support the new behavior.

Fixes #7