### PR TITLE
Add IgnorePosLine and deprecate IgnoreLine

### DIFF
--- a/comment.go
+++ b/comment.go
@@ -109,11 +109,24 @@ func (maps Maps) CommentsByPosLine(fset *token.FileSet, pos token.Pos) []*ast.Co
 	return nil
 }
 
+// Deprecated: This function does not work with multiple files.
 // IgnoreLine checks either specified lineof AST node is ignored by the check.
 // It follows staticcheck style as the below.
 //   //lint:ignore Check1[,Check2,...,CheckN] reason
 func (maps Maps) IgnoreLine(fset *token.FileSet, line int, check string) bool {
 	for _, cg := range maps.CommentsByLine(fset, line) {
+		if hasIgnoreCheck(cg, check) {
+			return true
+		}
+	}
+	return false
+}
+
+// IgnorePosLine checks either specified lineof AST node is ignored by the check.
+// It follows staticcheck style as the below.
+//   //lint:ignore Check1[,Check2,...,CheckN] reason
+func (maps Maps) IgnorePosLine(fset *token.FileSet, pos token.Pos, check string) bool {
+	for _, cg := range maps.CommentsByPosLine(fset, pos) {
 		if hasIgnoreCheck(cg, check) {
 			return true
 		}

--- a/comment_test.go
+++ b/comment_test.go
@@ -66,3 +66,31 @@ func TestMaps_IgnoreLine(t *testing.T) {
 		})
 	}
 }
+
+func TestMaps_IgnorePosLine(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		path  string
+		check string
+		want  bool
+	}{
+		"single": {"testdata/Maps_IgnorePosLine/single.go", "test-check", true},
+		"multi":  {"testdata/Maps_IgnorePosLine/multi.go", "test-check", true},
+	}
+
+	for n, tt := range cases {
+		tt := tt
+		t.Run(n, func(t *testing.T) {
+			t.Parallel()
+			fset := token.NewFileSet()
+			ms := maps(t, fset, tt.path)
+			p := pos(t, fset, tt.path)
+
+			got := ms.IgnorePosLine(fset, p, tt.check)
+			if tt.want != got {
+				t.Errorf("want %v, got %v", tt.want, got)
+			}
+		})
+	}
+}

--- a/testdata/Maps_IgnorePosLine/multi.go
+++ b/testdata/Maps_IgnorePosLine/multi.go
@@ -1,0 +1,10 @@
+-- a.go --
+package a
+
+func A() {}
+-- b.go --
+package a
+
+//lint:ignore test-check reason
+func B_() {
+}

--- a/testdata/Maps_IgnorePosLine/single.go
+++ b/testdata/Maps_IgnorePosLine/single.go
@@ -1,0 +1,7 @@
+-- a.go --
+package a
+
+//lint:ignore test-check reason
+func A_() {}
+
+func B() {}


### PR DESCRIPTION
fix: https://github.com/gostaticanalysis/comment/issues/8

This PR adds `IgnorePosLine` and deprecates `IgnoreLine`.

`CommentsByLine` is deprecated and `CommentsByPosLine` is recommended but `IgnoreLine` is still using `CommentsByLine` and an ignore-like function using `CommentsByPosLine` doesn't exist.